### PR TITLE
Add `position` option for use with `scaleMode`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
-  "name": "photoswipe",
-  "homepage": "http://photoswipe.com",
+  "name": "aligent-photoswipe",
   "authors": [
     "Dmitry Semenov <diiiimaaaa@gmail.com> (http://dimsemenov.com)"
   ],
@@ -23,7 +22,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/dimsemenov/PhotoSwipe.git"
+    "url": "git://github.com/aligent/PhotoSwipe.git"
   },
   "license": "MIT",
   "ignore": [

--- a/component.json
+++ b/component.json
@@ -1,9 +1,9 @@
 {
-  "name": "photoswipe",
-  "repository": "dimsemenov/PhotoSwipe",
+  "name": "aligent-photoswipe",
+  "repository": "aligent/PhotoSwipe",
   "description": "JavaScript gallery",
   "main": "dist/photoswipe.js",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "keywords": [
     "gallery",
     "lightbox",

--- a/dist/photoswipe-ui-default.js
+++ b/dist/photoswipe-ui-default.js
@@ -1,6 +1,6 @@
-/*! PhotoSwipe Default UI - 4.1.1 - 2015-12-24
+/*! PhotoSwipe Default UI - 4.1.1 - 2016-09-12
 * http://photoswipe.com
-* Copyright (c) 2015 Dmitry Semenov; */
+* Copyright (c) 2016 Dmitry Semenov; */
 /**
 *
 * UI on top of main sliding area (caption, arrows, close button, etc.).

--- a/dist/photoswipe.js
+++ b/dist/photoswipe.js
@@ -1,6 +1,6 @@
-/*! PhotoSwipe - v4.1.1 - 2015-12-24
+/*! PhotoSwipe - v4.1.1 - 2016-09-12
 * http://photoswipe.com
-* Copyright (c) 2015 Dmitry Semenov; */
+* Copyright (c) 2016 Dmitry Semenov; */
 (function (root, factory) { 
 	if (typeof define === 'function' && define.amd) {
 		define(factory);
@@ -1085,8 +1085,8 @@ var publicMethods = {
 		_currPanBounds = self.currItem.bounds;	
 		_startZoomLevel = _currZoomLevel = self.currItem.initialZoomLevel;
 
-		_panOffset.x = _currPanBounds.center.x;
-		_panOffset.y = _currPanBounds.center.y;
+		_panOffset.x = self.currItem.initialPosition.x;
+		_panOffset.y = self.currItem.initialPosition.y;
 
 		if(emulateSetContent) {
 			_shout('afterChange');
@@ -2725,6 +2725,23 @@ var _getItemAt,
 		bounds.min.x = (realPanElementW > _tempPanAreaSize.x) ? 0 : bounds.center.x;
 		bounds.min.y = (realPanElementH > _tempPanAreaSize.y) ? item.vGap.top : bounds.center.y;
 	},
+	_setInitialPosition = function(item) {
+		var positionOption = 'position' in _options ? _options.position : null;
+
+		item.initialPosition = item.initialPosition ||  {};
+		item.initialPosition.x = item.bounds.center.x;
+
+		switch (positionOption) {
+			case 'top':
+				item.initialPosition.y = item.bounds.min.y;
+				break;
+			case 'bottom':
+				item.initialPosition.y = item.bounds.max.y;
+				break;
+			default:
+				item.initialPosition.y = item.bounds.center.y;
+		}
+	},
 	_calculateItemSize = function(item, viewportSize, zoomLevel) {
 
 		if (item.src && !item.loadError) {
@@ -2776,7 +2793,7 @@ var _getItemAt,
 			_calculateSingleItemPanBounds(item, item.w * zoomLevel, item.h * zoomLevel);
 
 			if (isInitial && zoomLevel === item.initialZoomLevel) {
-				item.initialPosition = item.bounds.center;
+				_setInitialPosition(item);
 			}
 
 			return item.bounds;
@@ -3409,6 +3426,13 @@ _registerModule('DesktopZoom', {
 		},
 
 		toggleDesktopZoom: function(centerPoint) {
+			if (_options.scaleMode === 'orig') {
+				if (_options.tapToClose === true) {
+					this.close()
+				}
+				return;
+			}
+
 			centerPoint = centerPoint || {x:_viewportSize.x/2 + _offset.x, y:_viewportSize.y/2 + _offset.y };
 
 			var doubleTapZoomLevel = _options.getDoubleTapZoom(true, self.currItem);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "photoswipe",
-  "version": "4.1.1",
+  "name": "aligent-photoswipe",
+  "version": "4.2.0",
   "engines": {
     "node": ">= 0.8.0"
   },
@@ -24,13 +24,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/dimsemenov/Photoswipe.git"
+    "url": "git://github.com/aligent/Photoswipe.git"
   },
   "description": "JavaScript gallery",
-  "bugs": {
-    "url": "https://github.com/dimsemenov/Photoswipe/issues"
-  },
-  "homepage": "http://photoswipe.com",
   "main": "dist/photoswipe.js",
   "keywords": [
     "gallery",

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -787,8 +787,8 @@ var publicMethods = {
 		_currPanBounds = self.currItem.bounds;	
 		_startZoomLevel = _currZoomLevel = self.currItem.initialZoomLevel;
 
-		_panOffset.x = _currPanBounds.center.x;
-		_panOffset.y = _currPanBounds.center.y;
+		_panOffset.x = self.currItem.initialPosition.x;
+		_panOffset.y = self.currItem.initialPosition.y;
 
 		if(emulateSetContent) {
 			_shout('afterChange');

--- a/src/js/desktop-zoom.js
+++ b/src/js/desktop-zoom.js
@@ -155,6 +155,13 @@ _registerModule('DesktopZoom', {
 		},
 
 		toggleDesktopZoom: function(centerPoint) {
+			if (_options.scaleMode === 'orig') {
+				if (_options.tapToClose === true) {
+					this.close()
+				}
+				return;
+			}
+
 			centerPoint = centerPoint || {x:_viewportSize.x/2 + _offset.x, y:_viewportSize.y/2 + _offset.y };
 
 			var doubleTapZoomLevel = _options.getDoubleTapZoom(true, self.currItem);

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -50,6 +50,23 @@ var _getItemAt,
 		bounds.min.x = (realPanElementW > _tempPanAreaSize.x) ? 0 : bounds.center.x;
 		bounds.min.y = (realPanElementH > _tempPanAreaSize.y) ? item.vGap.top : bounds.center.y;
 	},
+	_setInitialPosition = function(item) {
+		var positionOption = 'position' in _options ? _options.position : null;
+
+		item.initialPosition = item.initialPosition ||  {};
+		item.initialPosition.x = item.bounds.center.x;
+
+		switch (positionOption) {
+			case 'top':
+				item.initialPosition.y = item.bounds.min.y;
+				break;
+			case 'bottom':
+				item.initialPosition.y = item.bounds.max.y;
+				break;
+			default:
+				item.initialPosition.y = item.bounds.center.y;
+		}
+	},
 	_calculateItemSize = function(item, viewportSize, zoomLevel) {
 
 		if (item.src && !item.loadError) {
@@ -101,7 +118,7 @@ var _getItemAt,
 			_calculateSingleItemPanBounds(item, item.w * zoomLevel, item.h * zoomLevel);
 
 			if (isInitial && zoomLevel === item.initialZoomLevel) {
-				item.initialPosition = item.bounds.center;
+				_setInitialPosition(item);
 			}
 
 			return item.bounds;


### PR DESCRIPTION
Fixes minor positioning glitches that occur in `scaleMode` and adds a `position` option to define the horizontal location when the image is first opened.
